### PR TITLE
fix: Quotation marks in the search no longer crashes application

### DIFF
--- a/Eplant/UI/LeftNav/GeneSearch/SearchBar.tsx
+++ b/Eplant/UI/LeftNav/GeneSearch/SearchBar.tsx
@@ -34,7 +34,8 @@ export default function SearchBar(props: {
 
   React.useEffect(() => {
     updateOptions.current = debounce(async (newValue) => {
-      setOptions((await props.complete?.(newValue)) ?? [])
+      const newoptions = await props.complete?.(newValue)
+      setOptions(newoptions?.length ? newoptions: [])
     }, 100)
   }, [props.complete])
   const id = React.useId()


### PR DESCRIPTION
The Bar API will usually return an empty array for its autocomplete results when no results are found, however when using quotation marks it returns an empty object for some reason. Since in JS empty objects and arrays are truthy, this results in an empty object being passed to in as "options" which results in a runtime error. Now this is checked and correctly passes in an empty array.