### PR TITLE
Fix reset panzoom in efp view and ensure thumbnails update

### DIFF
--- a/Eplant/util/PanZoom/index.tsx
+++ b/Eplant/util/PanZoom/index.tsx
@@ -11,10 +11,10 @@ export type Transform = {
 export default function PanZoom({
   children,
   onTransformChange,
-  initialTransform: transform,
+  transform,
   ...props
 }: BoxProps & {
-  initialTransform: Transform
+  transform: Transform
   onTransformChange: (transform: Transform) => void
 }) {
   const [dragStart, setDragStart] = React.useState<{

--- a/Eplant/views/eFP/Viewer/index.tsx
+++ b/Eplant/views/eFP/Viewer/index.tsx
@@ -416,7 +416,7 @@ export default class EFPViewer
                     height: '100%',
                     zIndex: 0,
                   })}
-                  initialTransform={props.state.transform}
+                  transform={props.state.transform}
                   onTransformChange={(transform) => {
                     props.dispatch({
                       type: 'set-transform',

--- a/Eplant/views/eFP/index.tsx
+++ b/Eplant/views/eFP/index.tsx
@@ -310,19 +310,6 @@ export default class EFP implements View<EFPData, EFPState, EFPAction> {
       }[]
     >([])
 
-    React.useLayoutEffect(() => {
-      const elements = Array.from(
-        props.activeData.groups.flatMap((group) =>
-          group.tissues.map((t) => ({
-            el: document.querySelector(`#${id} .efp-group-${t.id}`),
-            group,
-            tissue: t,
-          }))
-        )
-      )
-      setSvgElements(elements as any)
-    }, [props.activeData.groups, id])
-
     const svgDiv = React.useMemo(() => {
       return (
         <div
@@ -339,6 +326,19 @@ export default class EFP implements View<EFPData, EFPState, EFPAction> {
         />
       )
     }, [svg, id])
+
+    React.useLayoutEffect(() => {
+      const elements = Array.from(
+        props.activeData.groups.flatMap((group) =>
+          group.tissues.map((t) => ({
+            el: document.querySelector(`#${id} .efp-group-${t.id}`),
+            group,
+            tissue: t,
+          }))
+        )
+      )
+      setSvgElements(elements as any)
+    }, [props.activeData.groups, id, svgDiv])
 
     if (!svg) {
       return (


### PR DESCRIPTION
This fixes the reset pan/zoom button in efp viewers. Before the change it did nothing, now it behaves as expected.