### PR TITLE
fix: adds labels to scale (issue 50)

### DIFF
--- a/Eplant/views/eFP/Viewer/legend.tsx
+++ b/Eplant/views/eFP/Viewer/legend.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { Box, styled, useTheme } from '@mui/material'
 
 import { getColor } from '../svg'
@@ -39,7 +37,7 @@ export default styled(function Legend({
     .reverse()
     .map((g) =>
       getColor(
-        state.colorMode == 'absolute' ? g : 2 ** g * control,
+        state.colorMode === 'absolute' ? g : 2 ** g * control,
         data,
         data.control ?? 1,
         theme,
@@ -57,7 +55,6 @@ export default styled(function Legend({
         }}
       ></Box>
     ))
-
   return (
     <Box
       {...rest}
@@ -77,6 +74,15 @@ export default styled(function Legend({
         }}
       >
         {gradient}
+        <Box
+          sx={{
+            width: '15px',
+            height: '15px',
+            backgroundColor: 'gray',
+            display: 'inline-block',
+            fontSize: 10,
+          }}
+        ></Box>
       </Box>
       <Box
         sx={{
@@ -85,12 +91,16 @@ export default styled(function Legend({
           justifyContent: 'space-between',
         }}
       >
-        <Box sx={{ fontSize: 12 }}>{values[0].toFixed(0)}</Box>
-
-        <Box sx={{ fontSize: 12 }}>
-          {state.colorMode == 'absolute' ? '' : '0'}
-        </Box>
-        <Box sx={{ fontSize: 12 }}>{values[values.length - 1].toFixed(0)}</Box>
+        {values.map((value) => {
+          return (
+            <Box key={value} sx={{ fontSize: 10 }}>
+              {value.toFixed(2)}
+            </Box>
+          )
+        })}
+        <Box
+          sx={{ fontSize: 10 }}
+        >{`Masked (≥${state.maskThreshold}% RSE)`}</Box>
       </Box>
     </Box>
   )


### PR DESCRIPTION
Solves issue #50, partially solves issues #49 - at the moment, the masked value is not defined because the mask modal doesn't work and so can't update that value (afiak). If the masked value is undefined, the component displays 100 for now. 

<img width="1440" alt="Screenshot 2024-02-09 at 3 11 47 PM" src="https://github.com/BioAnalyticResource/ePlant/assets/7177924/93c8bff0-9fbe-4b44-8e80-34067c2dbf0a">

<img width="1440" alt="Screenshot 2024-02-09 at 3 10 51 PM" src="https://github.com/BioAnalyticResource/ePlant/assets/7177924/4ebebf8e-111f-4805-919e-0c9239284022">