### PR TITLE
chore: Github action for build on non-staging and main branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Build
+on:
+  push:
+    branches-ignore:
+      - main
+      - staging
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+      - run: npm ci
+      - run: npm run build
+        env:
+          BASE_URL: '/ePlant'


### PR DESCRIPTION
Add Github Action which will build on push to any branch except for staging and main (these have their own build + deploy Action)