### PR TITLE
Search icon becomes an Add icon when the search box isn't empty

### DIFF
--- a/Eplant/UI/LeftNav/GeneSearch/SearchBar.tsx
+++ b/Eplant/UI/LeftNav/GeneSearch/SearchBar.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { debounce } from 'lodash'
 
+import AddIcon from '@mui/icons-material/Add'
 import CloseIcon from '@mui/icons-material/Close'
 import SearchIcon from '@mui/icons-material/Search'
 import { SxProps, Theme } from '@mui/material'
@@ -118,7 +119,7 @@ export default function SearchBar(props: {
                     setValue([])
                   }}
                 >
-                  <SearchIcon />
+                  {value.length > 0 ? <AddIcon /> : <SearchIcon />}
                 </IconButton>
               </InputAdornment>
             ),

--- a/Eplant/UI/LeftNav/GeneSearch/index.tsx
+++ b/Eplant/UI/LeftNav/GeneSearch/index.tsx
@@ -39,6 +39,8 @@ export function SearchGroup({
   return (
     <Stack direction='column' spacing={2}>
       {/* Species selector */}
+
+      {/* Commenting this out until we get multi-species support 
       <TextField
         select
         size='small'
@@ -62,7 +64,7 @@ export function SearchGroup({
           </MenuItem>
         ))}
       </TextField>
-
+      */}
       {/* Gene selector */}
       <SearchBar
         label='Search for genes'


### PR DESCRIPTION
Changed the "Search" icon to an "Add" icon to indicate that the genes are ready to add to your list.

BEFORE
![Search bar - Search icon](https://github.com/BioAnalyticResource/ePlant/assets/4388484/d2ffff5b-ee52-4975-b131-f742a5ee0e61)


AFTER
![Search bar - Add icon](https://github.com/BioAnalyticResource/ePlant/assets/4388484/43d5fac9-892a-4705-ba01-ae6264cbbe63)
