### PR TITLE
chore: Github Action to mount Google Maps API key via Github Secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,7 @@ jobs:
         env:
           BASE_URL: '/ePlant'
           VITE_MAPS_API_KEY: ${{ secrets.VITE_MAPS_API_KEY }}
+          VITE_MAPS_API_KEY: ${{ secrets.VITE_MAPS_ID }}
       - run: mv dist _site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
       - staging
-      
+
 permissions:
   contents: read
   pages: write
@@ -27,7 +27,8 @@ jobs:
       - run: npm ci
       - run: npm run build
         env:
-          BASE_URL: "/ePlant"
+          BASE_URL: '/ePlant'
+          VITE_MAPS_API_KEY: ${{ secrets.VITE_MAPS_API_KEY }}
       - run: mv dist _site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2


### PR DESCRIPTION
Does nothing atm but once Google maps key is added as a github secret this will be mounted such that it will be available to our Github pages deployment. The key will also need to be made available to prod @asherpasha can you handle this?