### PR TITLE
fix: Fixed caching of EFP viewdata

### DIFF
--- a/Eplant/views/eFP/Viewer/index.tsx
+++ b/Eplant/views/eFP/Viewer/index.tsx
@@ -184,7 +184,6 @@ export default class EFPViewer
         zoom: 1,
       },
       viewData: viewData,
-      efps: this.efps,
       colorMode: 'absolute' as const,
     }
   }


### PR DESCRIPTION
Closes #139 

Issue was fixed by removing un-used field in EFP ViewData causing the object to be unserializable