### PR TITLE
chore: Add map id to deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,3 +24,4 @@ jobs:
         env:
           BASE_URL: '/ePlant'
           VITE_MAPS_API_KEY: ${{ secrets.VITE_MAPS_API_KEY }}
+          VITE_MAP_ID: ${{ secrets.VITE_MAP_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,8 @@ jobs:
         env:
           BASE_URL: '/ePlant'
           VITE_MAPS_API_KEY: ${{ secrets.VITE_MAPS_API_KEY }}
+          VITE_MAP_ID: ${{ secrets.VITE_MAP_ID }}
+
       - run: mv dist _site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Added `VITE_MAP_ID` env variable to deployment and build steps. This is required for the World EFP View

Will require addition of the variable as a secret if not already done @asherpasha 

How to create a map ID if not already done: https://developers.google.com/maps/documentation/maps-static/map-ids/get-map-id?_gl=1*v314zt*_up*MQ..*_ga*OTU1NDcyMTIwLjE3NTIwMTY4OTQ.*_ga_NRWSTWS78N*czE3NTIwMTY4OTQkbzEkZzEkdDE3NTIwMTY4OTQkajYwJGwwJGgw