### PR TITLE
fix: use experiment-wide min/max for eFP colour scale instead of group

### DIFF
--- a/Eplant/views/eFP/Viewer/EFPViewer.tsx
+++ b/Eplant/views/eFP/Viewer/EFPViewer.tsx
@@ -191,7 +191,7 @@ export const EFPViewer = ({
             borderRadius: 1,
           })}
         >
-          {data.viewData[activeViewIndex].supported ? (
+          {sortedViewData[activeViewIndex].supported ? (
             <>
               <div>
                 <Typography
@@ -204,7 +204,7 @@ export const EFPViewer = ({
                 </Typography>
 
                 <GeneDistributionChart
-                  data={{ ...data.viewData[activeViewIndex] }}
+                  data={{ ...sortedViewData[activeViewIndex] }}
                 />
               </div>
               <MaskModal
@@ -229,7 +229,7 @@ export const EFPViewer = ({
                   zIndex: 10,
                 })}
                 data={{
-                  ...data.viewData[activeViewIndex],
+                  ...sortedViewData[activeViewIndex],
                 }}
                 maskThreshold={state.maskThreshold}
                 colorMode={state.colorMode}

--- a/Eplant/views/eFP/svg.tsx
+++ b/Eplant/views/eFP/svg.tsx
@@ -124,12 +124,13 @@ export function getColor(
 
 export function useStyles(
   id: string,
-  { groups, control }: EFPData,
+  data: EFPData,
   colorMode: ColorMode,
   maskThreshold?: number,
   maskingEnabled?: boolean
 ) {
   const theme = useTheme()
+  const { groups, control } = data
   const samples = groups
     .flatMap((group) =>
       group.tissues.map(
@@ -138,7 +139,7 @@ export function useStyles(
             tissue.id
           } { fill: ${getColor(
             tissue.mean,
-            group,
+            data,
             control ?? 1,
             theme,
             colorMode,


### PR DESCRIPTION
This fix is directly on top of staging to fix the colouring issue where instead of pulling the experimental max, it was pulling the group-max for each tissue, often making things very red. Instead we want a global max. This also fixed the heat scale issue (sometimes doubling up and making weird glitches).

Technical:
Just fixed what is being passed and and sorted.

Before:
<img width="1673" height="1300" alt="image" src="https://github.com/user-attachments/assets/295c744c-c5c9-471d-9c36-f45070e1b16d" />

After:
<img width="1647" height="1323" alt="image" src="https://github.com/user-attachments/assets/8be2a2ee-e517-4bf1-a1a1-e6b4b4ad4055" />
