### PR TITLE
Fix/efp relative mode per group control from global control

### DIFF
--- a/Eplant/views/eFP/Viewer/EFPTooltip.tsx
+++ b/Eplant/views/eFP/Viewer/EFPTooltip.tsx
@@ -124,7 +124,8 @@ function SVGTooltip(props: {
                 <KeyValueRow
                   label='Log2 fold change vs control'
                   value={Math.log2(
-                    props.tissue.mean / (props.data.control ?? 1)
+                    props.tissue.mean /
+                      (props.group.control ?? props.data.control ?? 1)
                   ).toFixed(2)}
                 />
               </TableBody>

--- a/Eplant/views/eFP/Viewer/legend.tsx
+++ b/Eplant/views/eFP/Viewer/legend.tsx
@@ -1,7 +1,7 @@
 import { Box, styled, useTheme } from '@mui/material'
 
 import { getColor } from '../svg'
-import { ColorMode, EFPData, EFPState } from '../types'
+import { ColorMode, EFPData } from '../types'
 
 interface ILegendProps {
   data: EFPData
@@ -18,6 +18,11 @@ export default styled(function Legend({
   ...rest
 }: ILegendProps) {
   const theme = useTheme()
+  // TODO: legend uses data.control (cross-group average) and data.min/max as a
+  // global approximation. This can diverge from per-group colours when groups
+  // have different controls. A per-group legend is out of scope for this fix.
+  // I.e. The colours may not line up in this commit/PR due to group colours being different
+  // than the global legend
   const control = data.control ?? 1
   const values = Array(GRADIENT_STEPS)
     .fill(0)

--- a/Eplant/views/eFP/svg.tsx
+++ b/Eplant/views/eFP/svg.tsx
@@ -139,8 +139,8 @@ export function useStyles(
             tissue.id
           } { fill: ${getColor(
             tissue.mean,
-            data,
-            control ?? 1,
+            group,
+            group.control ?? control ?? 1,
             theme,
             colorMode,
             tissue.std,

--- a/Eplant/views/eFP/svg.tsx
+++ b/Eplant/views/eFP/svg.tsx
@@ -96,7 +96,8 @@ export function getColor(
   colorMode: ColorMode,
   tissueStd?: number,
   maskThreshold?: number,
-  maskingEnabled?: boolean
+  maskingEnabled?: boolean,
+  absoluteMax?: number
 ): string {
   const extremum = Math.max(
     Math.abs(Math.log2(group.min / control)),
@@ -118,7 +119,7 @@ export function getColor(
     return mix(
       theme.palette.neutral.main,
       theme.palette.hot.main,
-      value / group.max
+      value / (absoluteMax ?? group.max)
     )
 }
 
@@ -145,7 +146,8 @@ export function useStyles(
             colorMode,
             tissue.std,
             maskThreshold,
-            maskingEnabled
+            maskingEnabled,
+            data.max
           )} !important; }`
       )
     )


### PR DESCRIPTION
So there was an issue with colouring (both absolute [ fixed in #174 ] and now in relative [this fix]). Basically had to:

### **Problem**
The eFP relative color mode and log2 fold change tooltip were using data.control — the average of all group controls across the entire experiment — instead of each tissue's own group.control. This produced incorrect colours and values in any experiment where groups have different controls.

### **Summary of Fixes:**
- Fix the per-group control if it is exists to be the control (Sometimes it is indeed experiment or data wide) hence the ?? operator in Eplant/views/eFP/Viewer/EFPTooltip.tsx
- Make an absolute max for when a group max exists to co-exist with one another
- Pass group control correctly

**Before (Note that even the control samples are non-zero [they should always be 0 since its log 2 fold change of 1]):**
<img width="1480" height="743" alt="image" src="https://github.com/user-attachments/assets/4ea9fc4c-d3b1-4b59-963c-3505a4964f04" />


**After:**
<img width="1388" height="794" alt="image" src="https://github.com/user-attachments/assets/eb7972a7-78a4-4e8c-8eb1-f5877bc40c60" />

**Details:**

Commit 1 — per-group control for relative mode

EFPTooltip.tsx: tooltip log2 fold change now uses group.control (falls back to data.control, then 1)
svg.tsx: useStyles passes group instead of data to getColor, so the relative-mode extremum calculation scales against the group's own min/max and control
legend.tsx: removed unused EFPState import; added a comment noting the legend is a global approximation that may not exactly match per-group colours

Commit 2 — preserve absolute mode scaling

The first commit broke absolute mode: passing group to getColor meant absolute colours normalised against group.max instead of the experiment-wide data.max, making every tissue appear fully red
Added an optional absoluteMax parameter to getColor; absolute mode now uses absoluteMax ?? group.max
useStyles passes data.max as the new argument
legend.tsx unchanged — it already passes data as its group arg, so the fallback resolves correctly

What was NOT changed

The XML parser — group-level <control> tags are parsed correctly
The data shape in types.tsx or the loader in views/eFP/index.tsx — per-group control was already computed correctly; only downstream consumers were ignoring it, so we are just making sure it gets read
The data.control aggregate field — it remains as a fallback