### PR TITLE
Perf/efp single request

### DIFF
--- a/Eplant/views/eFP/index.tsx
+++ b/Eplant/views/eFP/index.tsx
@@ -97,10 +97,7 @@ export default class EFP {
     const samples: { [key: string]: number } = {}
 
     const fetchedSamples: { value: number; name: string }[] = await fetch(
-      webservice +
-        `id=${gene.id}&samples=${encodeURIComponent(
-          JSON.stringify(sampleNames)
-        )}`
+      webservice + `id=${gene.id}&samples=${JSON.stringify(sampleNames)}`
     )
       .then((res) => res.json())
       .then((data: any[]) =>

--- a/Eplant/views/eFP/index.tsx
+++ b/Eplant/views/eFP/index.tsx
@@ -95,40 +95,25 @@ export default class EFP {
 
     loadEvent(20)
     const samples: { [key: string]: number } = {}
-    // Fetch the sample names in chunks to give a more accurate progress bar
-    const chunks = _.chunk(sampleNames, 20)
-    let loaded = 20
-    const loadStep = (100 - loaded) / chunks.length
-    const data = (
-      await Promise.all(
-        chunks.map((names) =>
-          fetch(
-            webservice +
-              `id=${gene.id}&samples=${encodeURIComponent(
-                JSON.stringify(names)
-              )}`
-          )
-            .then((res) => res.json())
-            .then(
-              (samples) =>
-                samples
-                  .filter(
-                    (sample: any) => sample && !isNaN(parseFloat(sample.value))
-                  )
-                  .map((sample: any) => ({
-                    name: sample.name,
-                    value: parseFloat(sample.value),
-                  })) as { value: number; name: string }[]
-            )
-            .then((samples) => {
-              loaded += loadStep
-              loadEvent(loaded)
-              return samples
-            })
-        )
+
+    const fetchedSamples: { value: number; name: string }[] = await fetch(
+      webservice +
+        `id=${gene.id}&samples=${encodeURIComponent(
+          JSON.stringify(sampleNames)
+        )}`
+    )
+      .then((res) => res.json())
+      .then((data: any[]) =>
+        data
+          .filter((s) => s && !isNaN(parseFloat(s.value)))
+          .map((s) => ({
+            name: s.name,
+            value: parseFloat(s.value),
+          }))
       )
-    ).flat()
-    for (const { name, value } of data) samples[name] = value
+
+    loadEvent(80)
+    for (const { name, value } of fetchedSamples) samples[name] = value
     loadEvent(100)
     const groupsData = groups
       .map((group) => {

--- a/Eplant/views/eFP/index.tsx
+++ b/Eplant/views/eFP/index.tsx
@@ -97,7 +97,10 @@ export default class EFP {
     const samples: { [key: string]: number } = {}
 
     const fetchedSamples: { value: number; name: string }[] = await fetch(
-      webservice + `id=${gene.id}&samples=${JSON.stringify(sampleNames)}`
+      webservice +
+        `id=${gene.id}&samples=${JSON.stringify(sampleNames)
+          .replace(/\+/g, '%2B')
+          .replace(/ /g, '%20')}`
     )
       .then((res) => res.json())
       .then((data: any[]) =>


### PR DESCRIPTION
Synopsis:

So this PR just makes an update to the URL/URI encoding that was happening before. More or less there was multiple (5+; depending on how many samples a view had) calls to the webservice which fetches the tissue/sample data for SVGs/eFP views because it was afraid of the URL being too long and make the loading bar more smooth (load pieces of data instead at once). So a bunch of API calls were strung together. Had to make some minor modifications too to enable one long URL GET request versus 20 small ones. 

This PR shrunk the calls to webservice from 200+ to 45.

<img width="219" height="124" alt="image" src="https://github.com/user-attachments/assets/8ff503af-2474-4e23-aefa-848e5b1029b6" />

<img width="206" height="108" alt="image" src="https://github.com/user-attachments/assets/c7d5aae1-82ff-4903-9d02-8c8f35fc39b5" />

Detailed:

Previously we split that list into chunks of 20 samples and fired a separate request for each chunk — so one view could make 5+ requests, and loading all views for a gene meant 200+ requests at once. This changes it to one request per view, matching how the older ePlant 2 app worked. The chunking existed only to make the loading bar move more smoothly. In practice it multiplied network traffic for no real benefit and added load on the server. A single request is simpler and faster; the progress bar now steps at greater intervals instead of mini-steps but it's a worthy tradeoff. 

NB: The old code encoded the sample list with encodeURIComponent(JSON.stringify(names)) encodeURIComponent makes many chars into 3-char codes which made some URLs too long for large views. This wasn't a problem before but now to fix the 414 we dropped encodeURIComponent and sent JSON.stringify(names) directly. Also sample names containing + or spaces were being misread by the server, but it's fixed now.